### PR TITLE
Derive the sensor activation from the reading index

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Pick the one matching your model:
 ## Sensor treatments
 Set `uploader_sensor_events` to `True` to have the uploader record the sensor session in Nightscout as well as the readings.
 
-- `Sensor Start` is posted at `deviceEnableTime`, the sensor activation reported by Sisensing.
+- `Sensor Start` is posted at the activation worked out from the readings themselves. Each reading carries `i`, a minute index counted from activation, so `t - i` minutes gives the start from any reading in the response. Sisensing's own `deviceEnableTime` is not used: it is skewed by the local UTC offset minus 8 hours, which put it 2 hours late under AEST and 3 hours late under AEDT, late enough to post the start after the session's first reading. A sensor whose readings have all aged out of the response yields no `Sensor Start`.
 - `Sensor Stop` is posted at `latestGlucoseTime`, the final reading, once Sisensing reports the sensor as no longer running (`deviceStatus` other than `1`). The response carries no explicit stop time, and readings can continue for a few hours past the scheduled 14 day end, so the last reading is used rather than the schedule.
 
 Both are posted with `enteredBy` set to the uploader, and are skipped when Nightscout already holds that event at that time. Nightscout also upserts treatments on event type plus timestamp, so a repeat post overwrites rather than duplicates.

--- a/package/module.py
+++ b/package/module.py
@@ -253,14 +253,36 @@ def get_last_treatment(header,event_type):
         print("Last", event_type+":", data[0].get("created_at"))
         return data[0]
 
-# deviceEnableTime is the sensor activation and is in SECONDS, unlike every other
-# timestamp in the Sisensing response. deviceLastTime is activation plus 14 days,
-# a schedule rather than an observation, so it is not used as an event time.
-def prepare_treatment_sensorstart(device):
-    if not device.get("deviceEnableTime"):
-        print("No deviceEnableTime in response. Skipping Sensor Start.")
+# deviceEnableTime claims to be the activation and is in SECONDS, unlike every
+# other timestamp in the response, but it is skewed and cannot be used as an event
+# time. In sample_json/response_14d.json it sits 3h 1m after the sensor really
+# started; a live 2026-08-09 session put it 2h 1m after, an hour that is exactly
+# the AEDT to AEST change. The gap tracks the local UTC offset minus 8 hours, so
+# the field reads like a wall clock rendered in UTC+8 rather than a true epoch.
+#
+# Every reading instead carries "i", a minute index counted from activation, so
+# t - i*60000 recovers the real start from any reading with no timezone involved.
+# Readings disagree by up to a minute, so take the median rather than an edge:
+# in the 502 reading sample the median lands on the value 370 of them agree on.
+def sensor_activation_from_readings(device):
+    bases = []
+    for reading in flatten_list(recursively_get_glucoseinfos(device,'glucoseInfos')):
+        try:
+            bases.append(int(reading["t"]) - int(reading["i"])*60000)
+        except (TypeError, ValueError, KeyError):
+            continue
+    if len(bases) == 0:
         return None
-    start_date = int(device["deviceEnableTime"])*1000
+    bases.sort()
+    return bases[len(bases)//2]
+
+# deviceLastTime is activation plus 14 days, a schedule rather than an observation,
+# so it is not used as an event time either.
+def prepare_treatment_sensorstart(device):
+    start_date = sensor_activation_from_readings(device)
+    if start_date is None:
+        print("No glucose reading carries an index. Skipping Sensor Start.")
+        return None
     return {
         "eventType": "Sensor Start",
         "created_at": to_ns_datestring(start_date),
@@ -276,15 +298,21 @@ def prepare_treatment_sensorstop(device):
     status = device.get("deviceStatus")
     if status is None or status == 1:
         return None
-    if not device.get("latestGlucoseTime") or not device.get("deviceEnableTime"):
+    if not device.get("latestGlucoseTime"):
         print("Sensor is not running but the response has no usable stop time.")
         return None
 
     stop_date = int(device["latestGlucoseTime"])
-    start_date = int(device["deviceEnableTime"])*1000
+    # An expired sensor empties glucoseInfos, so the index is usually gone by the
+    # time a stop is posted. Fall back to deviceEnableTime here: it is skewed by a
+    # couple of hours, which is fine for a floor on a 14 day wear, and only a
+    # sanity check hangs on it. Without either the floor is skipped, not the stop.
+    start_date = sensor_activation_from_readings(device)
+    if start_date is None and device.get("deviceEnableTime"):
+        start_date = int(device["deviceEnableTime"])*1000
     # a stop at or before the activation would be a bad read, not a short wear
-    if stop_date <= start_date:
-        print("Ignoring Sensor Stop, latestGlucoseTime is not after deviceEnableTime.")
+    if start_date is not None and stop_date <= start_date:
+        print("Ignoring Sensor Stop, latestGlucoseTime is not after the activation.")
         return None
 
     return {


### PR DESCRIPTION
## The bug

`Sensor Start` was posted at Sisensing's `deviceEnableTime`. On the production
instance that landed **61 minutes after the session's first reading**:

```
previous session last reading   2026-08-08T06:38:02Z
new session first reading       2026-08-09T02:21:15Z
recorded Sensor Start           2026-08-09T03:22:15Z   <-- 61 min later
```

`deviceEnableTime` is skewed by the local UTC offset minus 8 hours, so it reads
like a wall clock rendered in UTC+8 rather than a true epoch. Three real
captures, two timezones, all consistent:

| capture | local offset | how late `deviceEnableTime` is |
|---|---|---|
| `sample_json/response_14d.json`, Dec 2024 | AEDT +11 | 3h 1m |
| a July 2026 capture | AEST +10 | 2h 1m |
| live Aug 2026 session | AEST +10 | 2h 1m |

## The fix

Every reading carries `i`, a minute index counted from activation, so
`t - i*60000` recovers the real start from any reading with no timezone in it.
Verified across all 502 readings of the December sample: they agree on one
instant within 56 seconds, and the median lands on the value 370 of them share.

- `prepare_treatment_sensorstart` now returns `None` when no reading carries an
  index, rather than falling back to the skewed field. An expired sensor empties
  `glucoseInfos`, so a stopped sensor yields no start at all instead of a wrong one.
- `prepare_treatment_sensorstop` keeps `deviceEnableTime` only as a sanity floor,
  where a couple of hours does not matter, and skips the floor rather than the
  stop when it is missing.
- README "Sensor treatments" section rewritten.

## Verification

Offline harness extended with asserted skews, 180 min under AEDT and 120 min
under AEST, both within a 2 minute tolerance, plus cases for readings with no
index and an unusable index. All checks pass. Tested locally against a live
instance by the maintainer.

No config, interface or opt-in behaviour changes, so this ships as v2.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
